### PR TITLE
Bring back AppImage and rpm support

### DIFF
--- a/images/kiosk/package.json
+++ b/images/kiosk/package.json
@@ -46,12 +46,16 @@
       "icon": "build/256x256.png",
       "executableName": "kiosk-browser",
       "target": [
-        "deb"
+        "deb",
+        "rpm",
+        "AppImage"
       ],
-      "category": "Internet",
-      "packageCategory": "Internet"
+      "category": "Network",
+      "packageCategory": "web"
     },
     "deb": {},
+    "rpm": {},
+    "appImage": {},
     "win": {
       "icon": "build/icon.ico"
     },


### PR DESCRIPTION
There is no need to remove rpm support and AppImage support has been fixed using the right keywords and by suppling valid categories.

Please verify that it's not breaking anything and if it's OK do a rebase via GitHub (without merge commit).