### PR TITLE
Process command line options and settings before app is fully initialized

### DIFF
--- a/images/kiosk/main.js
+++ b/images/kiosk/main.js
@@ -11,14 +11,15 @@ const electron = require('electron');
 // Module to control application life.
 const app = electron.app;
 
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-app.on('ready', function()
-{
-    
 const path = require('path');
+const fsExtra = require('fs-extra');
 const settings = require('electron-settings');
+const settingsPath = app.getPath('userData');
 
+// ensure that the directory for the settings actually exists
+// otherwise, electron-settings may fail if used before the 'ready' event
+fsExtra.ensureDirSync(settingsPath);
+console.log(settingsPath);
 // write defautl settings to Settings only file if it is empty
 const defaultSettings = require("./defaults.json");
 if(Object.keys(settings.getAll()).length==0)
@@ -289,6 +290,12 @@ process.on('uncaughtException', function(error) { // '='? '{}'?
    WARN('uncaughtException! :(');
    WARN(error);
 });
+
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+app.on('ready', function()
+{
 
 // Module to create native browser window.
 const BrowserWindow = electron.BrowserWindow

--- a/images/kiosk/package.json
+++ b/images/kiosk/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "electron-settings": "^3.1.4",
+    "fs-extra": "^7.0.1",
     "network": "^0.4.0",
     "os": "^0.1.1",
     "yargs": "^11.0.0"

--- a/images/kiosk/yarn.lock
+++ b/images/kiosk/yarn.lock
@@ -64,21 +64,9 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-array-filter@~0.0.0:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
-
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
-
-array-map@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
-
-array-reduce@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
 
 asar-integrity@0.2.4:
   version "0.2.4"
@@ -764,6 +752,14 @@ fs-extra@^5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1071,10 +1067,6 @@ jsonfile@^4.0.0:
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   optionalDependencies:
     graceful-fs "^4.1.6"
-
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -1706,15 +1698,6 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-
-shell-quote@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
-  dependencies:
-    array-filter "~0.0.0"
-    array-map "~0.0.0"
-    array-reduce "~0.0.0"
-    jsonify "~0.0.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Electron-settings is supposed to be only used after the app has triggered the 'ready' event and therefore we could only process the command line arguments and settings after that event. The side effect was that some Chrome command line switches had no effect because they were set to late in the initialization process. This commit ensures that the user data directory of the app is actually present and then just uses electron-settings before the 'ready' event. Even though this procedure is discouraged by the authors of electron-settings, it seems to just work fine. The existence of the user data directory seam to be the only real prerequisite when using electron-settings.

This should also fix #11.