### PR TITLE
Add argument ("background-color" of type string) to specify the

### DIFF
--- a/src/js/main/appReady.js
+++ b/src/js/main/appReady.js
@@ -212,9 +212,20 @@ function appReady(args) {
 
     if (args.preload)
         preloadModules.push(path.resolve(args.preload));
-
+ 
+    var backgroundColor = args.transparent ? args['background-color'].fade(1.0).hex() : args['background-color'].hex();
+    
+    // Color::hex seems to ignore the alpha component
+    if(args.transparent) 
+    {
+        if(backgroundColor.length == 7) // no alpha
+	{
+	    backgroundColor = backgroundColor.replace("#", "#00");
+	}
+    }
+    
     const options = {
-        backgroundColor: args.transparent ? '#0fff' : '#fff',
+        backgroundColor: backgroundColor,
         show: false,
         frame: args.frame && !args['cover-displays'],
         titleBarStyle: 'hidden',

--- a/src/js/main/cmdLine.js
+++ b/src/js/main/cmdLine.js
@@ -93,6 +93,21 @@ function coerceOverflow(s) {
     };
 }
 
+function coerceBackgroundColor(s)
+{
+    try {
+        const Color = require('color');
+        const c = Color(s);
+        if (c !== null) { 
+	    return c; 
+	}
+    } catch (error) {
+        throw new Error(`Invalid background color specification: ${s} (${error.message})`);
+    }
+    
+    throw new Error(`Invalid background color specification: ${s}`);
+}
+
 const options = {
     'help': {
         alias: 'h',
@@ -258,6 +273,13 @@ const options = {
         type: 'boolean',
         description: 'Show the browser window frame.',
         default: true,
+    },
+    'background-color': {
+        type: 'string',
+        description: 'Set background color for the main browser window before URL is loaded',
+        requiresArg: true,
+        default: "white",
+        coerce: coerceBackgroundColor
     },
     'resize': {
         type: 'boolean',


### PR DESCRIPTION
Browser-Window' background (e.g. during any refresh) instead of hardcoded white.

NOTE: transparency support is enabled despite a problem in Color library